### PR TITLE
GH-42

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,6 @@ We have provided three options that are formatted identically to the channel wel
 
 For saving these messages, they are stored as KV pairs. Team message pairs have the prefix `teammsg_<team_id>` to distinguish them from the `chanmsg_<channel_id>` pairs.
 
-The dynamic messages take priority in the case that a team has both a config.json message, and a dynamic one assigned. This is to leverage the ease of deleting KV pairs, compared to editing the config.json in real-time.
-
 ## Development
 
 This plugin contains a server and webapp portion.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ type MessageTemplate struct {
 }
 ```
 
-## How to Dynamically Assign Team Messages
+<!-- ## How to Dynamically Assign Team Messages
 
 This plugin also allows system admins and team admins to change the team message of an appropriate team through a slash command, rather than adjusting the config.json. 
 
@@ -207,7 +207,7 @@ We have provided three options that are formatted identically to the channel wel
 - `/welcomebot set_team_welcome [welcome message]` - sets the current team's welcome message to the one defined in the slash command.
 - `/welcomebot delete_team_welcome` - deletes the current team's welcome message. This however does NOT delete any messages set inside of the config.json.
 
-For saving these messages, they are stored as KV pairs. Team message pairs have the prefix `teammsg_<team_id>` to distinguish them from the `chanmsg_<channel_id>` pairs.
+For saving these messages, they are stored as KV pairs. Team message pairs have the prefix `teammsg_<team_id>` to distinguish them from the `chanmsg_<channel_id>` pairs. -->
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ type MessageTemplate struct {
 }
 ```
 
+## How to Dynamically Assign Team Messages
+
+This plugin also allows system admins and team admins to change the team message of an appropriate team through a slash command, rather than adjusting the config.json. 
+
+We have provided three options that are formatted identically to the channel welcomes:
+- `/welcomebot get_team_welcome` - prints the current team's welcome message if either the dynamic message exists, or the config.json message exists.
+- `/welcomebot set_team_welcome [welcome message]` - sets the current team's welcome message to the one defined in the slash command.
+- `/welcomebot delete_team_welcome` - deletes the current team's welcome message. This however does NOT delete any messages set inside of the config.json.
+
+For saving these messages, they are stored as KV pairs. Team message pairs have the prefix `teammsg_<team_id>` to distinguish them from the `chanmsg_<channel_id>` pairs.
+
+The dynamic messages take priority in the case that a team has both a config.json message, and a dynamic one assigned. This is to leverage the ease of deleting KV pairs, compared to editing the config.json in real-time.
+
 ## Development
 
 This plugin contains a server and webapp portion.

--- a/server/command.go
+++ b/server/command.go
@@ -32,7 +32,7 @@ const (
 	commandTriggerDeleteTeamWelcome    = "delete_team_welcome"
 
 	// Error Message Constants
-	unsetMessageError = "welcome message has not been set yet"
+	unsetMessageError = "welcome message has not been set"
 )
 
 func getCommand() *model.Command {
@@ -112,15 +112,15 @@ func (p *Plugin) validateCommand(action string, parameters []string) string {
 		}
 	case commandTriggerSetChannelWelcome:
 		if len(parameters) == 0 {
-			return "`set_channel_welcome` command requires the message to be provided"
+			return "`" + commandTriggerSetChannelWelcome + "` command requires the message to be provided"
 		}
 	case commandTriggerGetChannelWelcome:
 		if len(parameters) > 0 {
-			return "`get_channel_welcome` command does not accept any extra parameters"
+			return "`" + commandTriggerGetChannelWelcome + "` command does not accept any extra parameters"
 		}
 	case commandTriggerDeleteChannelWelcome:
 		if len(parameters) > 0 {
-			return "`delete_channel_welcome` command does not accept any extra parameters"
+			return "`" + commandTriggerDeleteChannelWelcome + "` command does not accept any extra parameters"
 		}
 	case commandTriggerSetTeamWelcome:
 		if len(parameters) == 0 {
@@ -160,7 +160,7 @@ func (p *Plugin) isSystemOrTeamAdmin(args *model.CommandArgs, userID string, tea
 	isTeamAdmin, teamAdminError := p.hasTeamAdminRole(userID, teamID)
 
 	if sysAdminError != nil {
-		p.postCommandResponse(args, "error occurred while getting the System Admin Role `%s`: `%s`", teamID, sysAdminError)
+		p.postCommandResponse(args, "error occurred while getting the System Admin Role: `%s`", sysAdminError)
 		return false
 	}
 	if teamAdminError != nil {
@@ -174,7 +174,7 @@ func (p *Plugin) isSystemOrTeamAdmin(args *model.CommandArgs, userID string, tea
 	return true
 }
 
-// This retrives a map of team Ids with their respective welcome message
+// This retrieves a map of team Ids with their respective welcome message
 func (p *Plugin) getTeamKVWelcomeMessagesMap(args *model.CommandArgs) map[string]string {
 	teamsList, teamErr := p.API.GetTeams()
 	if teamErr != nil {
@@ -295,7 +295,7 @@ func (p *Plugin) executeCommandSetWelcome(args *model.CommandArgs) {
 		return
 	}
 
-	p.postCommandResponse(args, "stored the welcome message:\n%s", message)
+	p.postCommandResponse(args, "stored the channel welcome message:\n%s", message)
 }
 
 func (p *Plugin) executeCommandGetWelcome(args *model.CommandArgs) {
@@ -353,7 +353,7 @@ func (p *Plugin) executeCommandSetTeamWelcome(args *model.CommandArgs) {
 		return
 	}
 
-	p.postCommandResponse(args, "stored the welcome message:\n%s", message)
+	p.postCommandResponse(args, "stored the team welcome message:\n%s", message)
 }
 
 func (p *Plugin) executeCommandDeleteTeamWelcome(args *model.CommandArgs) {
@@ -375,7 +375,7 @@ func (p *Plugin) executeCommandDeleteTeamWelcome(args *model.CommandArgs) {
 		return
 	}
 
-	p.postCommandResponse(args, "welcome message has been deleted")
+	p.postCommandResponse(args, "team welcome message has been deleted")
 }
 
 func (p *Plugin) executeCommandGetTeamWelcome(args *model.CommandArgs) {

--- a/server/command.go
+++ b/server/command.go
@@ -90,16 +90,17 @@ func (p *Plugin) hasChannelAdminRole(userID string, channelID string) (bool, err
 	return true, nil
 }
 
-func (p *Plugin) checkIfTownSquare(channelID string) (bool, error) {
-	channel, channelErr := p.API.GetChannel(channelID)
-	if channelErr != nil {
-		return false, channelErr
-	}
-	if channel.Name != model.DEFAULT_CHANNEL {
-		return false, nil
-	}
-	return true, nil
-}
+// Commented out for simplicity of welcome bot. Once restriction is wanted, this can be uncommented.
+// func (p *Plugin) checkIfTownSquare(channelID string) (bool, error) {
+// 	channel, channelErr := p.API.GetChannel(channelID)
+// 	if channelErr != nil {
+// 		return false, channelErr
+// 	}
+// 	if channel.Name != model.DEFAULT_CHANNEL {
+// 		return false, nil
+// 	}
+// 	return true, nil
+// }
 
 func (p *Plugin) validateCommand(action string, parameters []string) string {
 	switch action {

--- a/server/command.go
+++ b/server/command.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/plugin"
@@ -143,7 +142,7 @@ func (p *Plugin) validateCommand(action string, parameters []string) string {
 func (p *Plugin) validatePreviewPrivileges(teamID string, args *model.CommandArgs) bool {
 	_, teamMemberErr := p.API.GetTeamMember(teamID, args.UserId)
 	if teamMemberErr != nil {
-		if teamMemberErr.StatusCode == http.StatusNotFound {
+		if teamMemberErr.StatusCode == 404 {
 			p.postCommandResponse(args, "You are not a member of that team.")
 			return false
 		}

--- a/server/command.go
+++ b/server/command.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/plugin"
@@ -14,6 +15,9 @@ const commandHelp = `* |/welcomebot preview [team-name] | - preview the welcome 
 * |/welcomebot set_channel_welcome [welcome-message]| - set the welcome message for the given channel. Direct channels are not supported.
 * |/welcomebot get_channel_welcome| - print the welcome message set for the given channel (if any)
 * |/welcomebot delete_channel_welcome| - delete the welcome message for the given channel (if any)
+* |/welcomebot set_team_welcome [welcome-message]| - set a brief text welcome message for your given team.
+* |/welcomebot get_team_welcome| - print the welcome message set for the given team (if any)
+* |/welcomebot delete_team_welcome| - delete the dynamic welcome message for the given team (if any)
 `
 
 const (
@@ -23,6 +27,13 @@ const (
 	commandTriggerGetChannelWelcome    = "get_channel_welcome"
 	commandTriggerDeleteChannelWelcome = "delete_channel_welcome"
 	commandTriggerHelp                 = "help"
+	commandTriggerSetTeamWelcome       = "set_team_welcome"
+	commandTriggerGetTeamWelcome       = "get_team_welcome"
+	commandTriggerDeleteTeamWelcome    = "delete_team_welcome"
+
+	// Error Message Constants
+	teamRetrievalErr  = "error occurred while retrieving the welcome message for the team: `%s`"
+	unsetMessageError = "welcome message has not been set yet"
 )
 
 func getCommand() *model.Command {
@@ -31,7 +42,7 @@ func getCommand() *model.Command {
 		DisplayName:      "welcomebot",
 		Description:      "Welcome Bot helps add new team members to channels.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: preview, help, list, set_channel_welcome, get_channel_welcome, delete_channel_welcome",
+		AutoCompleteDesc: "Available commands: preview, help, list, set_channel_welcome, get_channel_welcome, delete_channel_welcome, set_team_welcome, get_team_welcome, delete_team_welcome",
 		AutoCompleteHint: "[command]",
 		AutocompleteData: getAutocompleteData(),
 	}
@@ -52,6 +63,39 @@ func (p *Plugin) hasSysadminRole(userID string) (bool, error) {
 		return false, appErr
 	}
 	if !strings.Contains(user.Roles, "system_admin") {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (p *Plugin) hasTeamAdminRole(userID string, teamID string) (bool, error) {
+	teamMember, appErr := p.API.GetTeamMember(teamID, userID)
+	if appErr != nil {
+		return false, appErr
+	}
+	if !strings.Contains(teamMember.Roles, "team_admin") {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (p *Plugin) hasChannelAdminRole(userID string, channelID string) (bool, error) {
+	channelMember, appErr := p.API.GetChannelMember(channelID, userID)
+	if appErr != nil {
+		return false, appErr
+	}
+	if !strings.Contains(channelMember.Roles, "channel_admin") {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (p *Plugin) checkIfTownSquare(channelID string) (bool, error) {
+	channel, channelErr := p.API.GetChannel(channelID)
+	if channelErr != nil {
+		return false, channelErr
+	}
+	if channel.DisplayName != "Town Square" {
 		return false, nil
 	}
 	return true, nil
@@ -79,40 +123,160 @@ func (p *Plugin) validateCommand(action string, parameters []string) string {
 		if len(parameters) > 0 {
 			return "`delete_channel_welcome` command does not accept any extra parameters"
 		}
+	case commandTriggerSetTeamWelcome:
+		if len(parameters) == 0 {
+			return "`" + commandTriggerSetTeamWelcome + "` command requires the message to be provided"
+		}
+	case commandTriggerGetTeamWelcome:
+		if len(parameters) > 0 {
+			return "`" + commandTriggerGetTeamWelcome + "` command does not accept any extra parameters"
+		}
+	case commandTriggerDeleteTeamWelcome:
+		if len(parameters) > 0 {
+			return "`" + commandTriggerDeleteTeamWelcome + "` command does not accept any extra parameters"
+		}
 	}
 
 	return ""
 }
 
-func (p *Plugin) executeCommandPreview(teamName string, args *model.CommandArgs) {
-	found := false
-	for _, message := range p.getWelcomeMessages() {
-		if message.TeamName == teamName {
-			if err := p.previewWelcomeMessage(teamName, args, *message); err != nil {
-				p.postCommandResponse(args, "error occurred while processing greeting for team `%s`: `%s`", teamName, err)
-				return
-			}
+func (p *Plugin) validatePreviewPrivileges(teamID string, args *model.CommandArgs) bool {
+	_, teamMemberErr := p.API.GetTeamMember(teamID, args.UserId)
+	if teamMemberErr != nil {
+		if teamMemberErr.StatusCode == http.StatusNotFound {
+			p.postCommandResponse(args, "You are not a member of that team.")
+			return false
+		}
+		p.postCommandResponse(args, "error occurred while getting the Team Admin Role `%s`: `%s`", teamID, teamMemberErr)
+		return false
+	}
+	doesUserHavePrivileges := p.checkForProperPrivileges(args, args.UserId, teamID)
 
-			found = true
+	return doesUserHavePrivileges
+}
+
+func (p *Plugin) checkForProperPrivileges(args *model.CommandArgs, userID string, teamID string) bool {
+	isSysadmin, sysAdminError := p.hasSysadminRole(userID)
+	isTeamAdmin, teamAdminError := p.hasTeamAdminRole(userID, teamID)
+
+	if sysAdminError != nil {
+		p.postCommandResponse(args, "error occurred while getting the System Admin Role `%s`: `%s`", teamID, sysAdminError)
+		return false
+	}
+	if teamAdminError != nil {
+		p.postCommandResponse(args, "error occurred while getting the Team Admin Role `%s`: `%s`", teamID, teamAdminError)
+		return false
+	}
+	if !isSysadmin && !isTeamAdmin {
+		p.postCommandResponse(args, "You do not have the proper privileges to control this Team's welcome messages.")
+		return false
+	}
+	return true
+}
+
+func (p *Plugin) showDynamicMessages(args *model.CommandArgs) bool {
+	// Checking dynamic welcome messages
+	teamsList, teamErr := p.API.GetTeams()
+	if teamErr != nil {
+		p.postCommandResponse(args, "Error occurred while getting list of teams: %s", teamErr)
+		return false
+	}
+
+	var dynamicTeamWelcome []string
+
+	for _, team := range teamsList {
+		key := fmt.Sprintf("%s%s", welcomebotTeamWelcomeKey, team.Id)
+		teamMessage, appErr := p.API.KVGet(key)
+		if appErr != nil {
+			p.postCommandResponse(args, "Error occurred while retrieving the welcome messages: %s", appErr)
+			return false
+		}
+		if teamMessage != nil {
+			dynamicTeamWelcome = append(dynamicTeamWelcome, team.DisplayName)
 		}
 	}
 
-	if !found {
-		p.postCommandResponse(args, "team `%s` has not been found", teamName)
+	if len(dynamicTeamWelcome) == 0 {
+		return false
 	}
+
+	var str strings.Builder
+	str.WriteString("Teams for which welcome messages are defined:")
+	for _, team := range dynamicTeamWelcome {
+		str.WriteString(fmt.Sprintf("\n * %s", team))
+	}
+	p.postCommandResponse(args, str.String())
+
+	return true
+}
+
+func (p *Plugin) executeCommandPreview(teamName string, args *model.CommandArgs) {
+	// Retrieve Team to check if a message already exists within the KV pair set
+	team, err := p.API.GetTeamByName(teamName)
+	if err != nil {
+		p.postCommandResponse(args, teamRetrievalErr, err)
+		return
+	}
+	teamID := team.Id
+
+	validPrivileges := p.validatePreviewPrivileges(teamID, args)
+	if !validPrivileges {
+		return
+	}
+
+	key := fmt.Sprintf("%s%s", welcomebotTeamWelcomeKey, teamID)
+	data, appErr := p.API.KVGet(key)
+	if appErr != nil {
+		p.postCommandResponse(args, teamRetrievalErr, appErr)
+		return
+	}
+
+	if len(data) == 0 {
+		// no dynamic message is set so we check the config for a message
+		found := false
+		for _, message := range p.getWelcomeMessages() {
+			if message.TeamName == teamName {
+				if err := p.previewWelcomeMessage(teamName, args, *message); err != nil {
+					p.postCommandResponse(args, "error occurred while processing greeting for team `%s`: `%s`", teamName, err)
+					return
+				}
+				found = true
+			}
+		}
+		if !found {
+			p.postCommandResponse(args, "team `%s` has not been found", teamName)
+		}
+		return
+	}
+	// Create ephemeral team welcome message
+	p.postCommandResponse(args, string(data))
 }
 
 func (p *Plugin) executeCommandList(args *model.CommandArgs) {
-	wecomeMessages := p.getWelcomeMessages()
+	isSysadmin, sysAdminError := p.hasSysadminRole(args.UserId)
+	if sysAdminError != nil {
+		p.postCommandResponse(args, "error occurred while getting the System Admin Role `%s`: `%s`", args.TeamId, sysAdminError)
+		return
+	}
+	if !isSysadmin {
+		p.postCommandResponse(args, "Only a System Admin can view all teams with welcome messages.")
+		return
+	}
 
-	if len(wecomeMessages) == 0 {
+	welcomeMessages := p.getWelcomeMessages()
+
+	if len(welcomeMessages) == 0 {
+		success := p.showDynamicMessages(args)
+		if success {
+			return
+		}
 		p.postCommandResponse(args, "There are no welcome messages defined")
 		return
 	}
 
 	// Deduplicate entries
 	teams := make(map[string]struct{})
-	for _, message := range wecomeMessages {
+	for _, message := range welcomeMessages {
 		teams[message.TeamName] = struct{}{}
 	}
 
@@ -120,6 +284,31 @@ func (p *Plugin) executeCommandList(args *model.CommandArgs) {
 	str.WriteString("Teams for which welcome messages are defined:")
 	for team := range teams {
 		str.WriteString(fmt.Sprintf("\n * %s", team))
+	}
+
+	// go through each key value pair and discern the teams with set values
+	page := 0
+	keys, err := p.API.KVList(page, 200)
+	if err != nil {
+		p.postCommandResponse(args, "Issue grabbing messages for teams.")
+		return
+	}
+	for len(keys) != 0 {
+		// retrieve id inside of kv pair
+		for _, key := range keys {
+			id := strings.ReplaceAll(key, welcomebotTeamWelcomeKey, "")
+			team, getTeamErr := p.API.GetTeam(id)
+			if getTeamErr != nil {
+				continue // the key is not corresponding to a team
+			}
+			str.WriteString(fmt.Sprintf("\n * %s", team.Name))
+		}
+		page++
+		keys, err = p.API.KVList(page, 200)
+		if err != nil {
+			p.postCommandResponse(args, "Issue grabbing messages for teams.")
+			return
+		}
 	}
 	p.postCommandResponse(args, str.String())
 }
@@ -131,7 +320,7 @@ func (p *Plugin) executeCommandSetWelcome(args *model.CommandArgs) {
 		return
 	}
 
-	if channelInfo.Type == model.CHANNEL_DIRECT {
+	if channelInfo.Type == model.CHANNEL_PRIVATE {
 		p.postCommandResponse(args, "welcome messages are not supported for direct channels")
 		return
 	}
@@ -188,6 +377,121 @@ func (p *Plugin) executeCommandDeleteWelcome(args *model.CommandArgs) {
 	p.postCommandResponse(args, "welcome message has been deleted")
 }
 
+func (p *Plugin) executeCommandSetTeamWelcome(args *model.CommandArgs) {
+	doesUserHavePrivileges := p.checkForProperPrivileges(args, args.UserId, args.TeamId)
+	if !doesUserHavePrivileges {
+		return
+	}
+
+	// Fields will consume ALL whitespace, so plain re-joining of the
+	// parameters slice will not produce the same message
+	message := strings.SplitN(args.Command, "set_team_welcome", 2)[1]
+	message = strings.TrimSpace(message)
+
+	key := fmt.Sprintf("%s%s", welcomebotTeamWelcomeKey, args.TeamId)
+	if appErr := p.API.KVSet(key, []byte(message)); appErr != nil {
+		p.postCommandResponse(args, "error occurred while storing the welcome message for the team: `%s`", appErr)
+		return
+	}
+
+	p.postCommandResponse(args, "stored the welcome message:\n%s", message)
+}
+
+func (p *Plugin) executeCommandDeleteTeamWelcome(args *model.CommandArgs) {
+	doesUserHavePrivileges := p.checkForProperPrivileges(args, args.UserId, args.TeamId)
+	if !doesUserHavePrivileges {
+		return
+	}
+	key := fmt.Sprintf("%s%s", welcomebotTeamWelcomeKey, args.TeamId)
+	data, appErr := p.API.KVGet(key)
+
+	if appErr != nil {
+		p.postCommandResponse(args, teamRetrievalErr, appErr)
+		return
+	}
+
+	if data == nil {
+		p.postCommandResponse(args, unsetMessageError)
+		return
+	}
+
+	if appErr := p.API.KVDelete(key); appErr != nil {
+		p.postCommandResponse(args, "error occurred while deleting the welcome message for the team: `%s`", appErr)
+		return
+	}
+
+	p.postCommandResponse(args, "welcome message has been deleted")
+}
+
+func (p *Plugin) executeCommandGetTeamWelcome(args *model.CommandArgs) {
+	doesUserHavePrivileges := p.checkForProperPrivileges(args, args.UserId, args.TeamId)
+	if !doesUserHavePrivileges {
+		return
+	}
+
+	key := fmt.Sprintf("%s%s", welcomebotTeamWelcomeKey, args.TeamId)
+	data, appErr := p.API.KVGet(key)
+	if appErr != nil {
+		p.postCommandResponse(args, teamRetrievalErr, appErr)
+		return
+	}
+
+	// retrieve team name through the teamid
+	team, err := p.API.GetTeam(args.TeamId)
+	if err != nil {
+		p.postCommandResponse(args, err.Error())
+		return
+	}
+
+	if data == nil {
+		for _, message := range p.getWelcomeMessages() {
+			if message.TeamName == team.Name {
+				if err := p.previewWelcomeMessage(team.Name, args, *message); err != nil {
+					p.postCommandResponse(args, "error occurred while processing greeting for team `%s`: `%s`", team.Name, err)
+				}
+				return
+			}
+		}
+		// if KV do not have message, and Config.json does not have message, then there is no message. Display Error case.
+		p.postCommandResponse(args, unsetMessageError)
+		return
+	}
+	p.postCommandResponse(args, string(data))
+}
+
+func (p *Plugin) verifyUser(args *model.CommandArgs) bool {
+	isSysadmin, err := p.hasSysadminRole(args.UserId)
+	if err != nil {
+		p.postCommandResponse(args, "authorization failed: %s", err)
+		return true
+	}
+	isTeamAdmin, teamAdminErr := p.hasTeamAdminRole(args.UserId, args.TeamId)
+	if teamAdminErr != nil {
+		p.postCommandResponse(args, "Team admin authorization failed: %s", teamAdminErr)
+		return true
+	}
+	isChannelAdmin, channelAdminErr := p.hasChannelAdminRole(args.UserId, args.ChannelId)
+	if channelAdminErr != nil {
+		p.postCommandResponse(args, "Channel admin authorization failed: %s", channelAdminErr)
+		return true
+	}
+	if !isSysadmin && !isTeamAdmin && !isChannelAdmin {
+		p.postCommandResponse(args, "/welcomebot commands can only be executed by the user with a system admin role, team admin role, or channel admin role")
+		return true
+	}
+
+	isTownSquare, channelErr := p.checkIfTownSquare(args.ChannelId)
+	if channelErr != nil {
+		p.postCommandResponse(args, "Channel authorization failed: %s", channelAdminErr)
+		return true
+	}
+	if !isSysadmin && !isTeamAdmin && isChannelAdmin && isTownSquare {
+		p.postCommandResponse(args, "/welcomebot commands cannot be executed by a channel admin in Town Square")
+		return true
+	}
+	return false
+}
+
 func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	split := strings.Fields(args.Command)
 	command := split[0]
@@ -209,13 +513,8 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 		return &model.CommandResponse{}, nil
 	}
 
-	isSysadmin, err := p.hasSysadminRole(args.UserId)
-	if err != nil {
-		p.postCommandResponse(args, "authorization failed: %s", err)
-		return &model.CommandResponse{}, nil
-	}
-	if !isSysadmin {
-		p.postCommandResponse(args, "/welcomebot commands can only be executed by the user with system admin role")
+	errorOccurred := p.verifyUser(args)
+	if errorOccurred {
 		return &model.CommandResponse{}, nil
 	}
 
@@ -236,6 +535,15 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 	case commandTriggerDeleteChannelWelcome:
 		p.executeCommandDeleteWelcome(args)
 		return &model.CommandResponse{}, nil
+	case commandTriggerSetTeamWelcome:
+		p.executeCommandSetTeamWelcome(args)
+		return &model.CommandResponse{}, nil
+	case commandTriggerGetTeamWelcome:
+		p.executeCommandGetTeamWelcome(args)
+		return &model.CommandResponse{}, nil
+	case commandTriggerDeleteTeamWelcome:
+		p.executeCommandDeleteTeamWelcome(args)
+		return &model.CommandResponse{}, nil
 	case commandTriggerHelp:
 		fallthrough
 	case "":
@@ -250,7 +558,8 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 
 func getAutocompleteData() *model.AutocompleteData {
 	welcomebot := model.NewAutocompleteData("welcomebot", "[command]",
-		"Available commands: preview, help, list, set_channel_welcome, get_channel_welcome, delete_channel_welcome")
+		"Available commands: preview, help, list, set_channel_welcome, get_channel_welcome, delete_channel_welcome, "+
+			commandTriggerSetTeamWelcome+", "+commandTriggerGetTeamWelcome+", "+commandTriggerDeleteTeamWelcome)
 
 	preview := model.NewAutocompleteData("preview", "[team-name]", "Preview the welcome message for the given team name")
 	preview.AddTextArgument("Team name to preview welcome message", "[team-name]", "")
@@ -268,6 +577,16 @@ func getAutocompleteData() *model.AutocompleteData {
 
 	deleteChannelWelcome := model.NewAutocompleteData("delete_channel_welcome", "", "Delete the welcome message for the channel")
 	welcomebot.AddCommand(deleteChannelWelcome)
+
+	setTeamWelcome := model.NewAutocompleteData(commandTriggerSetTeamWelcome, "[welcome-message]", "Set the welcome message for the team")
+	setChannelWelcome.AddTextArgument("Welcome message for the current team", "[welcome-message]", "")
+	welcomebot.AddCommand(setTeamWelcome)
+
+	getTeamWelcome := model.NewAutocompleteData(commandTriggerGetTeamWelcome, "", "Print the welcome message for the team")
+	welcomebot.AddCommand(getTeamWelcome)
+
+	deleteTeamWelcome := model.NewAutocompleteData(commandTriggerDeleteTeamWelcome, "", "Delete the welcome message for the team. Configuration based messages are not affected by this.")
+	welcomebot.AddCommand(deleteTeamWelcome)
 
 	return welcomebot
 }

--- a/server/command.go
+++ b/server/command.go
@@ -512,7 +512,6 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 
 func (p *Plugin) getUniqueTeamsWithWelcomeMsgSlice(teamsWithConfigWelcome map[string]struct{}, teamsWithKVWelcome map[string]string) []string {
 	var uniqueTeams []string
-	var allTeamNames []string
 	// Place all keys into one list
 	teamsWithConfigWelcomeKeys := convertStringMapIntoKeySlice(teamsWithConfigWelcome)
 	teamIDsWithKVWelcomeKeys := convertStringMapIntoKeySlice(teamsWithKVWelcome)
@@ -526,7 +525,7 @@ func (p *Plugin) getUniqueTeamsWithWelcomeMsgSlice(teamsWithConfigWelcome map[st
 		}
 		teamsWithKVWelcomeKeys = append(teamsWithKVWelcomeKeys, team.Name)
 	}
-	allTeamNames = append(teamsWithConfigWelcomeKeys, teamsWithKVWelcomeKeys...)
+	allTeamNames := append(teamsWithConfigWelcomeKeys, teamsWithKVWelcomeKeys...)
 
 	// Leverage the unique priniciple of keys in a map to store unique values as they are encountered
 	checkMap := make(map[string]int)
@@ -539,7 +538,6 @@ func (p *Plugin) getUniqueTeamsWithWelcomeMsgSlice(teamsWithConfigWelcome map[st
 		uniqueTeams = append(uniqueTeams, teamName)
 	}
 	return uniqueTeams
-
 }
 
 // Takes maps whose keys are strings, and whose values are anything.

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -1,5 +1,11 @@
 package main
 
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
 const (
 	actionTypeAutomatic = "automatic"
 	actionTypeButton    = "button"
@@ -63,4 +69,14 @@ func (p *Plugin) OnConfigurationChange() error {
 	p.welcomeMessages.Store(c.WelcomeMessages)
 
 	return nil
+}
+
+// Takes a teamID to construct the correct key, and then retrieve the necessary value from the pair stored in the DB
+func (p *Plugin) GetTeamWelcomeMessageFromKV(teamID string) ([]byte, *model.AppError) {
+	key := makeTeamWelcomeMessageKey(teamID)
+	return p.API.KVGet(key)
+}
+
+func makeTeamWelcomeMessageKey(teamID string) string {
+	return fmt.Sprintf("%s%s", welcomebotTeamWelcomeKey, teamID)
 }

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -27,7 +27,7 @@ func (p *Plugin) UserHasJoinedTeam(c *plugin.Context, teamMember *model.TeamMemb
 	}
 
 	if teamMessage == nil {
-		// No dynamic welcome message for the given team, so we check if one as been set in the config.json
+		// No dynamic welcome message for the given team, so we check if one has been set in the config.json
 		for _, message := range p.getWelcomeMessages() {
 			if message.TeamName == data.Team.Name {
 				go p.processWelcomeMessage(*data, *message)
@@ -39,11 +39,10 @@ func (p *Plugin) UserHasJoinedTeam(c *plugin.Context, teamMember *model.TeamMemb
 	// We send a DM and an opportunistic ephemeral message to the channel. See
 	// the discussion at the link below for more details:
 	// https://github.com/mattermost/mattermost-plugin-welcomebot/pull/31#issuecomment-611691023
-	teamAddMessage := "# Welcome to the " + data.Team.DisplayName + " team!! \n\n"
 	postDM := &model.Post{
 		UserId:    p.botUserID,
 		ChannelId: data.DirectMessage.Id,
-		Message:   teamAddMessage + string(teamMessage),
+		Message:   string(teamMessage),
 	}
 	if _, appErr := p.API.CreatePost(postDM); appErr != nil {
 		mlog.Error("failed to post welcome message to the channel",

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -17,25 +17,64 @@ func (p *Plugin) UserHasJoinedTeam(c *plugin.Context, teamMember *model.TeamMemb
 		return
 	}
 
-	for _, message := range p.getWelcomeMessages() {
-		if message.TeamName == data.Team.Name {
-			go p.processWelcomeMessage(*data, *message)
-		}
+	key := fmt.Sprintf("%s%s", welcomebotTeamWelcomeKey, teamMember.TeamId)
+	teamMessage, appErr := p.API.KVGet(key)
+	if appErr != nil {
+		mlog.Error(
+			"error occurred while retrieving the welcome message",
+			mlog.String("teamId", teamMember.TeamId),
+			mlog.Err(appErr),
+		)
+		return
 	}
+
+	if teamMessage == nil {
+		// No dynamic welcome message for the given team, so we check if one as been set in the config.json
+		for _, message := range p.getWelcomeMessages() {
+			if message.TeamName == data.Team.Name {
+				go p.processWelcomeMessage(*data, *message)
+			}
+		}
+		return
+	}
+
+	// We send a DM and an opportunistic ephemeral message to the channel. See
+	// the discussion at the link below for more details:
+	// https://github.com/mattermost/mattermost-plugin-welcomebot/pull/31#issuecomment-611691023
+	teamAddMessage := "# Welcome to the " + data.Team.DisplayName + " team!! \n\n"
+	postDM := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: data.DirectMessage.Id,
+		Message:   teamAddMessage + string(teamMessage),
+	}
+	if _, appErr := p.API.CreatePost(postDM); appErr != nil {
+		mlog.Error("failed to post welcome message to the channel",
+			mlog.String("channelId", data.DirectMessage.Id),
+			mlog.Err(appErr),
+		)
+	}
+
+	postChannel := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: teamMember.TeamId,
+		Message:   string(teamMessage),
+	}
+	time.Sleep(1 * time.Second)
+	_ = p.API.SendEphemeralPost(teamMember.UserId, postChannel)
 }
 
 // UserHasJoinedChannel is invoked after the membership has been committed to
 // the database. If actor is not nil, the user was invited to the channel by
 // the actor.
-func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, _ *model.User) {
-	if channelInfo, appErr := p.API.GetChannel(channelMember.ChannelId); appErr != nil {
+func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
+	channelInfo, appErr := p.API.GetChannel(channelMember.ChannelId)
+	if appErr != nil {
+		fmt.Print("CHANNEL NAME: " + channelInfo.Name)
 		mlog.Error(
 			"error occurred while checking the type of the chanel",
 			mlog.String("channelId", channelMember.ChannelId),
 			mlog.Err(appErr),
 		)
-		return
-	} else if channelInfo.Type == model.CHANNEL_PRIVATE {
 		return
 	}
 
@@ -68,10 +107,12 @@ func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.Ch
 	// We send a DM and an opportunistic ephemeral message to the channel. See
 	// the discussion at the link below for more details:
 	// https://github.com/mattermost/mattermost-plugin-welcomebot/pull/31#issuecomment-611691023
+	channelAddMessage := "# Welcome to the " + channelInfo.DisplayName + " channel. \n\n"
+
 	postDM := &model.Post{
 		UserId:    p.botUserID,
 		ChannelId: dmChannel.Id,
-		Message:   string(data),
+		Message:   channelAddMessage + string(data),
 	}
 	if _, appErr := p.API.CreatePost(postDM); appErr != nil {
 		mlog.Error("failed to post welcome message to the channel",
@@ -85,6 +126,12 @@ func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.Ch
 		ChannelId: channelMember.ChannelId,
 		Message:   string(data),
 	}
-	time.Sleep(1 * time.Second)
+
+	if actor.Id == channelMember.UserId {
+		time.Sleep(3 * time.Second)
+	} else {
+		time.Sleep(15 * time.Second)
+	}
+
 	_ = p.API.SendEphemeralPost(channelMember.UserId, postChannel)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -14,6 +14,7 @@ const (
 	botDescription = "A bot account created by the Welcomebot plugin."
 
 	welcomebotChannelWelcomeKey = "chanmsg_"
+	welcomebotTeamWelcomeKey    = "teammsg_"
 )
 
 // Plugin represents the welcome bot plugin


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

### Summary
<!--
A description of what this pull request does.
-->

*This Pull Request adds new functionality* that allows a team admin or system admin to adjust a dynamic team-welcome message. Previously, the only way a team message could be set was to adjust the config.json, and then redeploy the instance of mattermost. This has caused certain team admins over at Platform 1 to seek out a resolution that allows for the dynamic ability to set their team welcome message without adjusting the config.json.

*With this new functionality*, we have added 3 new slash commands that allow a user with the appropriate credentials to set, get, and delete what we are calling `dynamic team messages` with the following commands:

* `get_team_welcome` - Grabs the stored dynamic team message (if it exists), or retrieves the config.json message set. 
* `set_team_welcome [new message]` - Stores internally a new KV pair where the key is the team id joined with the prefix: "teammsg_", and where the value is the message. This does not override the config.json value though.
* `delete_team_welcome` - This deletes the KV pair set for the team without ever touching the config.json message (if it exists).

If a dynamic team message is found, then the get call will retrieve that first. If a user ever wanted to resort back to the config.json message, they will just need to delete the dynamic message. All values will defer to the config.json message if no dynamic message is found.

This new functionality also allows appropriate team admins to have access to the above slash commands, rather than permitting only system admins. 

Also, on line 115, I fixed a misspelling of the word 'welcome.' 

Please let me know if this is the direction you would like to pursue regarding the solution to issue 42! If there is anything that I left out of this PR, I would be more than happy to add that necessary information! Thank you! 

### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-plugin-welcomebot/issues/42