### PR TITLE
[MM-390]: Added functionality to add user to all public channel in the team at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ where
     - **ActionDisplayName**: Sets the display name for the user action buttons.
     - **ActionName**: Sets the action name used by the plugin to identify which action is taken by a user.
     - **ActionSuccessfulMessage**: Message posted after the user takes this action and joins the specified channels.
-    - **ChannelsAddedTo**: List of channel names the user is added to. Must be the channel handle used in the URL, in lowercase. For example, in the following URL the **channel name** value is `my-channel`: https://example.com/my-team/channels/my-channel
+    - **ChannelsAddedTo**: List of channel names the user is added to. Must be the channel handle used in the URL, in lowercase. For example, in the following URL the **channel name** value is `my-channel`: https://example.com/my-team/channels/my-channel. If you want to add the user in the all the public channels of the team add "*" in the `ChannelsAddedTo` array.
 
 The preview of the configured messages, as well as the creation of a channel welcome message, can be done via bot commands:
 * `/welcomebot help` - Displays usage information.

--- a/server/welcomebot.go
+++ b/server/welcomebot.go
@@ -232,6 +232,7 @@ func (p *Plugin) joinChannel(action *Action, channelName string) {
 		perPage := 100
 		page := 0
 		for {
+			// Adding user to all the public channels only in case of all i.e. *
 			channels, appErr := p.API.GetPublicChannelsForTeam(action.Context.TeamID, page, perPage)
 			if appErr != nil {
 				p.API.LogError("Failed to get all the public channels for the team", "team_id", action.Context.TeamID)

--- a/server/welcomebot.go
+++ b/server/welcomebot.go
@@ -236,7 +236,7 @@ func (p *Plugin) joinChannel(action *Action, channelName string) {
 	if channelName == "*" {
 		page := defaultPage
 		for {
-			// Adding user to all the public channels when channel name in '*' (i.e. all)
+			// Adding user to all the public channels when channel name is '*' (i.e. all)
 			channels, err := p.client.Channel.ListPublicChannelsForTeam(action.Context.TeamID, page, defaultPerPage)
 			if err != nil {
 				p.client.Log.Error("Failed to get all the public channels for the team", "team_id", action.Context.TeamID, "error", err.Error())
@@ -262,7 +262,7 @@ func (p *Plugin) joinChannel(action *Action, channelName string) {
 				return
 			}
 		} else {
-			p.client.Log.Error("failed to get channel, continuing to the next channel", "channel_name", channelName, "user_id", action.Context.UserID, "error", err.Error())
+			p.client.Log.Error("Failed to get channel, continuing to the next channel", "channel_name", channelName, "user_id", action.Context.UserID, "error", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Added functionality to add users to all the team's public channels at once.
This can be achieved by adding `*` to _ChannelsAddedTo_ in the config.json(as described in readme)