### PR TITLE
[MM-83]: Restrict welcomebot from sending welcome messages & adding to channel if user is a bot

### DIFF
--- a/server/hooks.go
+++ b/server/hooks.go
@@ -31,7 +31,7 @@ func (p *Plugin) UserHasJoinedTeam(c *plugin.Context, teamMember *model.TeamMemb
 // UserHasJoinedChannel is invoked after the membership has been committed to
 // the database. If actor is not nil, the user was invited to the channel by
 // the actor.
-func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, user *model.User) {
+func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, _ *model.User) {
 	if channelInfo, appErr := p.API.GetChannel(channelMember.ChannelId); appErr != nil {
 		mlog.Error(
 			"error occurred while checking the type of the chanel",

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -31,64 +31,66 @@ func (p *Plugin) UserHasJoinedTeam(c *plugin.Context, teamMember *model.TeamMemb
 // UserHasJoinedChannel is invoked after the membership has been committed to
 // the database. If actor is not nil, the user was invited to the channel by
 // the actor.
-func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, _ *model.User) {
-	if channelInfo, appErr := p.API.GetChannel(channelMember.ChannelId); appErr != nil {
-		mlog.Error(
-			"error occurred while checking the type of the chanel",
-			mlog.String("channelId", channelMember.ChannelId),
-			mlog.Err(appErr),
-		)
-		return
-	} else if channelInfo.Type == model.ChannelTypePrivate {
-		return
-	}
+func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, user *model.User) {
+	if !user.IsBot {
+		if channelInfo, appErr := p.API.GetChannel(channelMember.ChannelId); appErr != nil {
+			mlog.Error(
+				"error occurred while checking the type of the chanel",
+				mlog.String("channelId", channelMember.ChannelId),
+				mlog.Err(appErr),
+			)
+			return
+		} else if channelInfo.Type == model.ChannelTypePrivate {
+			return
+		}
 
-	key := fmt.Sprintf("%s%s", welcomebotChannelWelcomeKey, channelMember.ChannelId)
-	data, appErr := p.API.KVGet(key)
-	if appErr != nil {
-		mlog.Error(
-			"error occurred while retrieving the welcome message",
-			mlog.String("channelId", channelMember.ChannelId),
-			mlog.Err(appErr),
-		)
-		return
-	}
+		key := fmt.Sprintf("%s%s", welcomebotChannelWelcomeKey, channelMember.ChannelId)
+		data, appErr := p.API.KVGet(key)
+		if appErr != nil {
+			mlog.Error(
+				"error occurred while retrieving the welcome message",
+				mlog.String("channelId", channelMember.ChannelId),
+				mlog.Err(appErr),
+			)
+			return
+		}
 
-	if data == nil {
-		// No welcome message for the given channel
-		return
-	}
+		if data == nil {
+			// No welcome message for the given channel
+			return
+		}
 
-	dmChannel, err := p.API.GetDirectChannel(channelMember.UserId, p.botUserID)
-	if err != nil {
-		mlog.Error(
-			"error occurred while creating direct channel to the user",
-			mlog.String("UserId", channelMember.UserId),
-			mlog.Err(err),
-		)
-		return
-	}
+		dmChannel, err := p.API.GetDirectChannel(channelMember.UserId, p.botUserID)
+		if err != nil {
+			mlog.Error(
+				"error occurred while creating direct channel to the user",
+				mlog.String("UserId", channelMember.UserId),
+				mlog.Err(err),
+			)
+			return
+		}
 
-	// We send a DM and an opportunistic ephemeral message to the channel. See
-	// the discussion at the link below for more details:
-	// https://github.com/mattermost/mattermost-plugin-welcomebot/pull/31#issuecomment-611691023
-	postDM := &model.Post{
-		UserId:    p.botUserID,
-		ChannelId: dmChannel.Id,
-		Message:   string(data),
-	}
-	if _, appErr := p.API.CreatePost(postDM); appErr != nil {
-		mlog.Error("failed to post welcome message to the channel",
-			mlog.String("channelId", dmChannel.Id),
-			mlog.Err(appErr),
-		)
-	}
+		// We send a DM and an opportunistic ephemeral message to the channel. See
+		// the discussion at the link below for more details:
+		// https://github.com/mattermost/mattermost-plugin-welcomebot/pull/31#issuecomment-611691023
+		postDM := &model.Post{
+			UserId:    p.botUserID,
+			ChannelId: dmChannel.Id,
+			Message:   string(data),
+		}
+		if _, appErr := p.API.CreatePost(postDM); appErr != nil {
+			mlog.Error("failed to post welcome message to the channel",
+				mlog.String("channelId", dmChannel.Id),
+				mlog.Err(appErr),
+			)
+		}
 
-	postChannel := &model.Post{
-		UserId:    p.botUserID,
-		ChannelId: channelMember.ChannelId,
-		Message:   string(data),
+		postChannel := &model.Post{
+			UserId:    p.botUserID,
+			ChannelId: channelMember.ChannelId,
+			Message:   string(data),
+		}
+		time.Sleep(1 * time.Second)
+		_ = p.API.SendEphemeralPost(channelMember.UserId, postChannel)
 	}
-	time.Sleep(1 * time.Second)
-	_ = p.API.SendEphemeralPost(channelMember.UserId, postChannel)
 }

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -32,65 +32,63 @@ func (p *Plugin) UserHasJoinedTeam(c *plugin.Context, teamMember *model.TeamMemb
 // the database. If actor is not nil, the user was invited to the channel by
 // the actor.
 func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, user *model.User) {
-	if !user.IsBot {
-		if channelInfo, appErr := p.API.GetChannel(channelMember.ChannelId); appErr != nil {
-			mlog.Error(
-				"error occurred while checking the type of the chanel",
-				mlog.String("channelId", channelMember.ChannelId),
-				mlog.Err(appErr),
-			)
-			return
-		} else if channelInfo.Type == model.ChannelTypePrivate {
-			return
-		}
-
-		key := fmt.Sprintf("%s%s", welcomebotChannelWelcomeKey, channelMember.ChannelId)
-		data, appErr := p.API.KVGet(key)
-		if appErr != nil {
-			mlog.Error(
-				"error occurred while retrieving the welcome message",
-				mlog.String("channelId", channelMember.ChannelId),
-				mlog.Err(appErr),
-			)
-			return
-		}
-
-		if data == nil {
-			// No welcome message for the given channel
-			return
-		}
-
-		dmChannel, err := p.API.GetDirectChannel(channelMember.UserId, p.botUserID)
-		if err != nil {
-			mlog.Error(
-				"error occurred while creating direct channel to the user",
-				mlog.String("UserId", channelMember.UserId),
-				mlog.Err(err),
-			)
-			return
-		}
-
-		// We send a DM and an opportunistic ephemeral message to the channel. See
-		// the discussion at the link below for more details:
-		// https://github.com/mattermost/mattermost-plugin-welcomebot/pull/31#issuecomment-611691023
-		postDM := &model.Post{
-			UserId:    p.botUserID,
-			ChannelId: dmChannel.Id,
-			Message:   string(data),
-		}
-		if _, appErr := p.API.CreatePost(postDM); appErr != nil {
-			mlog.Error("failed to post welcome message to the channel",
-				mlog.String("channelId", dmChannel.Id),
-				mlog.Err(appErr),
-			)
-		}
-
-		postChannel := &model.Post{
-			UserId:    p.botUserID,
-			ChannelId: channelMember.ChannelId,
-			Message:   string(data),
-		}
-		time.Sleep(1 * time.Second)
-		_ = p.API.SendEphemeralPost(channelMember.UserId, postChannel)
+	if channelInfo, appErr := p.API.GetChannel(channelMember.ChannelId); appErr != nil {
+		mlog.Error(
+			"error occurred while checking the type of the chanel",
+			mlog.String("channelId", channelMember.ChannelId),
+			mlog.Err(appErr),
+		)
+		return
+	} else if channelInfo.Type == model.ChannelTypePrivate {
+		return
 	}
+
+	key := fmt.Sprintf("%s%s", welcomebotChannelWelcomeKey, channelMember.ChannelId)
+	data, appErr := p.API.KVGet(key)
+	if appErr != nil {
+		mlog.Error(
+			"error occurred while retrieving the welcome message",
+			mlog.String("channelId", channelMember.ChannelId),
+			mlog.Err(appErr),
+		)
+		return
+	}
+
+	if data == nil {
+		// No welcome message for the given channel
+		return
+	}
+
+	dmChannel, err := p.API.GetDirectChannel(channelMember.UserId, p.botUserID)
+	if err != nil {
+		mlog.Error(
+			"error occurred while creating direct channel to the user",
+			mlog.String("UserId", channelMember.UserId),
+			mlog.Err(err),
+		)
+		return
+	}
+
+	// We send a DM and an opportunistic ephemeral message to the channel. See
+	// the discussion at the link below for more details:
+	// https://github.com/mattermost/mattermost-plugin-welcomebot/pull/31#issuecomment-611691023
+	postDM := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: dmChannel.Id,
+		Message:   string(data),
+	}
+	if _, appErr := p.API.CreatePost(postDM); appErr != nil {
+		mlog.Error("failed to post welcome message to the channel",
+			mlog.String("channelId", dmChannel.Id),
+			mlog.Err(appErr),
+		)
+	}
+
+	postChannel := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: channelMember.ChannelId,
+		Message:   string(data),
+	}
+	time.Sleep(1 * time.Second)
+	_ = p.API.SendEphemeralPost(channelMember.UserId, postChannel)
 }

--- a/server/welcomebot.go
+++ b/server/welcomebot.go
@@ -228,22 +228,22 @@ func (p *Plugin) processActionMessage(messageTemplate MessageTemplate, action *A
 }
 
 func (p *Plugin) joinChannel(action *Action, channelName string) {
-	user, appErr := p.API.GetUser(action.Context.UserID)
-	if appErr != nil {
-		p.API.LogError("Couldn't get user details. UserID: `%s` Error: `%s`", action.Context.UserID, appErr.Error())
+	user, err := p.client.User.Get(action.Context.UserID)
+	if err != nil {
+		p.client.Log.Error("Couldn't get user details", "user_id", action.Context.UserID, "error", err.Error())
 		return
 	}
 	if user.IsBot {
-		p.API.LogInfo("Skipping adding this user to the channel since it is a bot. UserID: `%s`", action.Context.UserID)
+		p.client.Log.Info("Skipping adding this user to the channel since it is a bot.", "user_id", action.Context.UserID)
 		return
 	}
 
-	if channel, err := p.API.GetChannelByName(action.Context.TeamID, channelName, false); err == nil {
-		if _, err := p.API.AddChannelMember(channel.Id, action.Context.UserID); err != nil {
-			p.API.LogError("Couldn't add user to the channel, continuing to next channel. UserID: `%s` ChannelID: `%s`", action.Context.UserID, channel.Id)
+	if channel, err := p.client.Channel.GetByName(action.Context.TeamID, channelName, false); err == nil {
+		if _, err = p.client.Channel.AddMember(channel.Id, action.Context.UserID); err != nil {
+			p.client.Log.Error("Couldn't add user to the channel, continuing to the next channel", "user_id", action.Context.UserID, "channel_id", channel.Id, "error", err.Error())
 			return
 		}
 	} else {
-		p.API.LogError("Failed to get channel, continuing to the next channel. ChannelName: `%s` UserID: `%s`", channelName, action.Context.UserID)
+		p.client.Log.Error("Failed to get the channel, continuing to the next channel.", "channel_name", channelName, "user_id", action.Context.UserID, "error", err.Error())
 	}
 }

--- a/server/welcomebot.go
+++ b/server/welcomebot.go
@@ -230,20 +230,20 @@ func (p *Plugin) processActionMessage(messageTemplate MessageTemplate, action *A
 func (p *Plugin) joinChannel(action *Action, channelName string) {
 	user, appErr := p.API.GetUser(action.Context.UserID)
 	if appErr != nil {
-		p.API.LogError("Couldn't get user details", "user_id", action.Context.UserID)
+		p.API.LogError("Couldn't get user details. UserID: `%s` Error: `%s`", action.Context.UserID, appErr.Error())
 		return
 	}
 	if user.IsBot {
-		p.API.LogInfo("Skipping adding this user to the channel since it is a bot", "user_id", action.Context.UserID)
+		p.API.LogInfo("Skipping adding this user to the channel since it is a bot. UserID: `%s`", action.Context.UserID)
 		return
 	}
 
 	if channel, err := p.API.GetChannelByName(action.Context.TeamID, channelName, false); err == nil {
 		if _, err := p.API.AddChannelMember(channel.Id, action.Context.UserID); err != nil {
-			p.API.LogError("Couldn't add user to the channel, continuing to next channel", "user_id", action.Context.UserID, "channel_id", channel.Id)
+			p.API.LogError("Couldn't add user to the channel, continuing to next channel. UserID: `%s` ChannelID: `%s`", action.Context.UserID, channel.Id)
 			return
 		}
 	} else {
-		p.API.LogError("failed to get channel, continuing to the next channel", "channel_name", channelName, "user_id", action.Context.UserID)
+		p.API.LogError("Failed to get channel, continuing to the next channel. ChannelName: `%s` UserID: `%s`", channelName, action.Context.UserID)
 	}
 }

--- a/server/welcomebot.go
+++ b/server/welcomebot.go
@@ -228,6 +228,16 @@ func (p *Plugin) processActionMessage(messageTemplate MessageTemplate, action *A
 }
 
 func (p *Plugin) joinChannel(action *Action, channelName string) {
+	user, appErr := p.API.GetUser(action.Context.UserID)
+	if appErr != nil {
+		p.API.LogError("Couldn't get user details", "user_id", action.Context.UserID)
+		return
+	}
+	if user.IsBot {
+		p.API.LogInfo("Skipping adding this user to the channel since it is a bot", "user_id", action.Context.UserID)
+		return
+	}
+
 	if channel, err := p.API.GetChannelByName(action.Context.TeamID, channelName, false); err == nil {
 		if _, err := p.API.AddChannelMember(channel.Id, action.Context.UserID); err != nil {
 			p.API.LogError("Couldn't add user to the channel, continuing to next channel", "user_id", action.Context.UserID, "channel_id", channel.Id)


### PR DESCRIPTION
## Summary
Restrict the welcome bot from adding to the channel if the user is a bot. All actions will be skipped for bot users.

## Ticket Link
https://github.com/mattermost-community/mattermost-plugin-welcomebot/issues/83

## What to test
1) Add a bot user to the team, and all the actions of the welcome bot plugin will be skipped. 